### PR TITLE
Fix propogate bug in apostrophe-pages.applyPermissions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1567,7 +1567,7 @@ function pages(options, callback) {
       if (propagateUnset) {
         command.$unset = propagateUnset;
       }
-      return apos.pages.update({ path: new RegExp('^' + RegExp.quote(page.path) + '/') }, command, callback);
+      return apos.pages.update({ path: new RegExp('^' + RegExp.quote(page.path) + '/') }, command, { multi: true }, callback);
     } else {
       return callback(null);
     }


### PR DESCRIPTION
MongoDB "multi" option defaults to false, meaning changes to subpages aren't updated properly in this function. Adding multi: true in the options object fixes this.
