### PR TITLE
don't overwrite options.sort

### DIFF
--- a/index.js
+++ b/index.js
@@ -804,7 +804,9 @@ function pages(options, callback) {
       optionsArg = {};
       criteriaArg = {};
     }
-    var options = {};
+    var options = {
+      sort: {level: 1, rank: 1}
+    };
     extend(true, options, optionsArg);
     _.defaults(options, {
       root: ''
@@ -832,7 +834,6 @@ function pages(options, callback) {
       // subset of them
       options.areas = false;
     }
-    options.sort = { level: 1, rank: 1 };
 
     apos.get(req, criteria, options, function(err, results) {
       if (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-pages",
-  "version": "0.5.85",
+  "version": "0.5.86",
   "description": "Adds trees of pages to the Apostrophe content management system",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I just wanted to pass the `sort` property and noticed, that it's overwritten...